### PR TITLE
Fix pipeline usage, lazy-load base BERT model, and retain embedding batch dimension

### DIFF
--- a/app/model.py
+++ b/app/model.py
@@ -3,14 +3,27 @@ from transformers import BertTokenizer, BertModel, pipeline
 
 class BERTModel:
     def __init__(self, model_name='bert-base-uncased'):
-        self.tokenizer = BertTokenizer.from_pretrained(model_name)
-        self.model = BertModel.from_pretrained(model_name)
-        self.model.eval()
+        self.model_name = model_name
+        self.tokenizer = None
+        self.model = None
 
-        self.sentiment_analyzer = pipeline("sentiment-analysis", model=self.model, tokenizer=self.tokenizer)
-        self.entity_extractor = pipeline("ner", model=self.model, tokenizer=self.tokenizer)
+        # Use task-specific pretrained models for sentiment analysis and NER instead
+        # of the base ``BertModel``.  Passing the raw ``BertModel`` to these
+        # pipelines raises errors because it lacks the classification heads
+        # required for the tasks.
+        self.sentiment_analyzer = pipeline("sentiment-analysis")
+        self.entity_extractor = pipeline("ner")
+
+        # Lazily load the base model only when embedding utilities are used.
+
+    def _ensure_base_model(self):
+        if self.model is None or self.tokenizer is None:
+            self.tokenizer = BertTokenizer.from_pretrained(self.model_name)
+            self.model = BertModel.from_pretrained(self.model_name)
+            self.model.eval()
 
     def get_embeddings(self, input_texts):
+        self._ensure_base_model()
         encoded_inputs = self.tokenizer.batch_encode_plus(
             input_texts,
             add_special_tokens=True,
@@ -24,18 +37,22 @@ class BERTModel:
 
         with torch.no_grad():
             outputs = self.model(input_ids, attention_mask=attention_mask)
-
-        embeddings = outputs.last_hidden_state.squeeze(0)
-        embeddings = embeddings.tolist()
+        # ``outputs.last_hidden_state`` already has shape
+        # (batch_size, sequence_length, hidden_size). Converting directly to a
+        # list preserves the batch dimension for single and multi-sample
+        # inputs alike.
+        embeddings = outputs.last_hidden_state.tolist()
 
         return embeddings
 
     def tokenize_text(self, input_text):
+        self._ensure_base_model()
         tokens = self.tokenizer.tokenize(input_text)
         return tokens
 
     def get_word_embeddings(self, input_text):
-        tokens = self.tokenize_text(input_text)
+        self._ensure_base_model()
+        tokens = self.tokenizer.tokenize(input_text)
         input_ids = self.tokenizer.convert_tokens_to_ids(tokens)
         input_ids = torch.tensor([input_ids])
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,95 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+import torch
+
+# Ensure the application package is importable when tests are executed from the
+# "tests" directory.
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from app.model import BERTModel
+
+
+class DummyTokenizer:
+    def batch_encode_plus(
+        self,
+        texts,
+        add_special_tokens=True,
+        padding='longest',
+        truncation=True,
+        return_tensors='pt',
+    ):
+        token_lists = [t.split() for t in texts]
+        seq_lengths = [len(tokens) + 2 for tokens in token_lists]
+        max_len = max(seq_lengths)
+
+        input_ids = []
+        attention_masks = []
+        for seq_len in seq_lengths:
+            ids = list(range(seq_len)) + [0] * (max_len - seq_len)
+            mask = [1] * seq_len + [0] * (max_len - seq_len)
+            input_ids.append(ids)
+            attention_masks.append(mask)
+
+        return {
+            'input_ids': torch.tensor(input_ids),
+            'attention_mask': torch.tensor(attention_masks),
+        }
+
+    def tokenize(self, text):
+        return text.split()
+
+    def convert_tokens_to_ids(self, tokens):
+        return list(range(len(tokens)))
+
+
+class DummyModel:
+    def eval(self):
+        pass
+
+    def __call__(self, input_ids, attention_mask=None):
+        batch, seq_len = input_ids.shape
+        hidden = 8
+        return type('obj', (), {'last_hidden_state': torch.zeros(batch, seq_len, hidden)})
+
+
+@pytest.fixture
+def model():
+    # Patch the expensive task-specific pipelines and base model/tokenizer so
+    # tests do not require external downloads.
+    with patch('app.model.pipeline') as mock_pipeline:
+        mock_pipeline.return_value = lambda x: x
+
+        def dummy_ensure(self):
+            if self.model is None or self.tokenizer is None:
+                self.tokenizer = DummyTokenizer()
+                self.model = DummyModel()
+
+        with patch.object(BERTModel, '_ensure_base_model', dummy_ensure):
+            yield BERTModel()
+
+
+def test_get_embeddings_single_input_shape(model):
+    embeddings = model.get_embeddings(["Hello world"])
+    assert isinstance(embeddings, list)
+    assert len(embeddings) == 1
+    seq_len = len(embeddings[0])
+    hidden_size = len(embeddings[0][0])
+    assert seq_len > 0
+    assert hidden_size > 0
+
+
+def test_get_embeddings_multi_input_shape(model):
+    embeddings = model.get_embeddings(["Hello world", "Another sentence"])
+    assert isinstance(embeddings, list)
+    assert len(embeddings) == 2
+    seq_len0 = len(embeddings[0])
+    seq_len1 = len(embeddings[1])
+    hidden_size0 = len(embeddings[0][0])
+    hidden_size1 = len(embeddings[1][0])
+    assert seq_len0 == seq_len1
+    assert hidden_size0 == hidden_size1
+    assert seq_len0 > 0
+    assert hidden_size0 > 0


### PR DESCRIPTION
## Summary
- use task-specific pretrained models for sentiment analysis and NER
- lazily load tokenizer and base BERT weights only when embedding utilities are invoked
- preserve batch dimension in `get_embeddings` so outputs match batch size
- add tests verifying embedding shapes for single and multiple inputs

## Testing
- `python -m py_compile app/model.py app/api.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895aca151b88332964cc820b6028831